### PR TITLE
[#15]✨  feat: 메인페이지 캐러셀 구현 및 레이아웃 작업

### DIFF
--- a/components/Layout/Footer/styled.ts
+++ b/components/Layout/Footer/styled.ts
@@ -6,8 +6,8 @@ export const FooterWrapper = styled.footer`
   background-color: ${(props) => props.theme.colors.white};
   border-top: 2px solid ${(props) => props.theme.colors.border};
   color: ${(props) => props.theme.colors.primary};
-  position: absolute;
-  bottom: 0;
+  /* position: absolute;
+  bottom: 0; */
 `;
 // 하단 고정 코드 개선 필요
 // position: absolute;

--- a/components/Layout/index.tsx
+++ b/components/Layout/index.tsx
@@ -1,0 +1,15 @@
+import { ReactNode } from 'react';
+import Footer from './Footer';
+import Header from './Header';
+
+const Layout = ({ children }: { children: ReactNode }) => {
+  return (
+    <>
+      <Header />
+      {children}
+      <Footer />
+    </>
+  );
+};
+
+export default Layout;

--- a/components/common/card/project/ProjectDesktopCard/index.tsx
+++ b/components/common/card/project/ProjectDesktopCard/index.tsx
@@ -26,7 +26,7 @@ const ProjectDesktopCard = ({ data }: { data: ProjectDummyData }) => {
       />
       <TagsWrapper>
         {data.categories.map((category) => (
-          <CardTags tag={category} />
+          <CardTags tag={category} key={category} />
         ))}
         <CardState state={data.state} />
       </TagsWrapper>

--- a/components/common/card/project/ProjectMobileCard/index.tsx
+++ b/components/common/card/project/ProjectMobileCard/index.tsx
@@ -38,8 +38,10 @@ const ProjectMobileCard = ({ data }: { data: ProjectDummyData }) => {
         {data.categories.length > 2
           ? data.categories
               .slice(0, 3)
-              .map((category) => <CardTags tag={category} />)
-          : data.categories.map((category) => <CardTags tag={category} />)}
+              .map((category) => <CardTags tag={category} key={category} />)
+          : data.categories.map((category) => (
+              <CardTags tag={category} key={category} />
+            ))}
       </TagsWrapper>
       <TotalUser>
         모집인원 {data.currentUser} / {data.totalUser}

--- a/components/common/card/study/StudyDesktopCard.tsx
+++ b/components/common/card/study/StudyDesktopCard.tsx
@@ -26,15 +26,15 @@ const StudyDesktopCard = ({
           <Image
             src={'/images/icon/heart_active.svg'}
             alt="heart"
-            width={24}
-            height={24}
+            width={20}
+            height={18}
           />
         ) : (
           <Image
             src={'/images/icon/heart.svg'}
             alt="heart"
-            width={24}
-            height={24}
+            width={20}
+            height={18}
           />
         )}
       </StudyCardTop>

--- a/components/common/card/study/styled.ts
+++ b/components/common/card/study/styled.ts
@@ -8,12 +8,14 @@ export const StudyCardWrapper = styled.div`
   gap: 10px;
   width: 253px;
   height: 193px;
+  padding: 10px;
 `;
 
 export const StudyCardTop = styled.div`
+  width: 100%;
   display: flex;
   align-items: center;
-  gap: 170px;
+  justify-content: space-between;
 `;
 
 export const StudyCardBottom = styled.div`

--- a/components/main/CardCarousel/index.tsx
+++ b/components/main/CardCarousel/index.tsx
@@ -1,0 +1,66 @@
+import styled from 'styled-components';
+import Image from 'next/image';
+import { ReactNode, useState } from 'react';
+
+import {
+  CardCarouselContent,
+  CardCarouselWrapper,
+  CarouselStyled,
+  CardCarouselNextButton,
+  CardCarouselNextButtonWrapper,
+  CardCarouselPrevButton,
+  CardCarouselPrevButtonWrapper,
+  CardCarouselContentWrapper,
+} from './styled';
+
+const CardCarousel = ({ children }: { children: ReactNode }) => {
+  const [currentPage, setCurrentPage] = useState(0);
+
+  const onClickNextButton = () => {
+    if (currentPage > 1) {
+      return;
+    }
+    setCurrentPage((prev) => prev + 1);
+  };
+
+  const onClickPrevButton = () => {
+    if (currentPage < 1) {
+      return;
+    }
+    setCurrentPage((prev) => prev - 1);
+  };
+
+  return (
+    <CardCarouselWrapper>
+      <CarouselStyled>
+        <CardCarouselPrevButtonWrapper>
+          <CardCarouselPrevButton onClick={onClickPrevButton}>
+            <Image
+              src={'/images/icon/chevron_prev.svg'}
+              alt={'prev button'}
+              width={12}
+              height={20}
+            />
+          </CardCarouselPrevButton>
+        </CardCarouselPrevButtonWrapper>
+        <CardCarouselContentWrapper>
+          <CardCarouselContent currentPage={currentPage}>
+            {children}
+          </CardCarouselContent>
+        </CardCarouselContentWrapper>
+        <CardCarouselNextButtonWrapper>
+          <CardCarouselNextButton onClick={onClickNextButton}>
+            <Image
+              src={'/images/icon/chevron_next.svg'}
+              alt={'next button'}
+              width={12}
+              height={20}
+            />
+          </CardCarouselNextButton>
+        </CardCarouselNextButtonWrapper>
+      </CarouselStyled>
+    </CardCarouselWrapper>
+  );
+};
+
+export default CardCarousel;

--- a/components/main/CardCarousel/styled.ts
+++ b/components/main/CardCarousel/styled.ts
@@ -1,0 +1,92 @@
+import styled from 'styled-components';
+
+export const CardCarouselWrapper = styled.div`
+  margin: 0 auto;
+  width: 1140px;
+  height: auto;
+  padding: 0 10px;
+`;
+
+export const CarouselStyled = styled.div`
+  width: 100%;
+  height: 100%;
+  position: relative;
+  box-sizing: border-box;
+`;
+
+export const CardCarouselPrevButtonWrapper = styled.div`
+  width: 40px;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: #ffffff;
+  position: absolute;
+  left: 0;
+  top: 0;
+  transition: all 0.2s ease-in-out;
+  z-index: 3333;
+`;
+
+export const CardCarouselPrevButton = styled.div`
+  width: 40px;
+  height: 40px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 8px;
+  background-color: #ffffff;
+  cursor: pointer;
+
+  :hover {
+    background-color: ${(props) => props.theme.colors.border};
+  }
+`;
+
+export const CardCarouselNextButtonWrapper = styled.div`
+  width: 40px;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: #ffffff;
+  position: absolute;
+  right: 0;
+  top: 0;
+  transition: all 0.2s ease-in-out;
+  z-index: 3333;
+`;
+
+export const CardCarouselNextButton = styled.div`
+  width: 40px;
+  height: 40px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 8px;
+  background-color: #ffffff;
+  cursor: pointer;
+
+  :hover {
+    background-color: ${(props) => props.theme.colors.border};
+  }
+`;
+
+export const CardCarouselContentWrapper = styled.div`
+  width: 100%;
+  height: 100%;
+  padding: 0 40px;
+  overflow: hidden;
+`;
+
+export const CardCarouselContent = styled.div<{ currentPage: number }>`
+  width: calc(200%);
+  height: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: nowrap;
+  transition: all 0.5s ease-in-out;
+  transform: ${(props) => `translateX(${props.currentPage * -25}%)`};
+  overflow: hidden;
+`;

--- a/components/main/MainNewContent/index.tsx
+++ b/components/main/MainNewContent/index.tsx
@@ -1,0 +1,65 @@
+import styled from 'styled-components';
+import CardCarousel from '../CardCarousel';
+import ProjectDesktopCard from '../../common/card/project/ProjectDesktopCard';
+import StudyDesktopCard from '../../common/card/study/StudyDesktopCard';
+import type { ProjectDummyData } from '../../../pages';
+const MainNewContentWrapper = styled.div`
+  max-width: 1140px;
+  margin: 0 auto;
+  padding: 40px 0;
+`;
+
+const MainNewContentTitle = styled.h1`
+  font-weight: 700;
+  font-size: 19px;
+  color: ${(props) => props.theme.colors.primary};
+  margin-bottom: 24px;
+  padding: 10px;
+`;
+
+const MainNewContent = ({ category }: { category: string }) => {
+  const ProjectDummyData: ProjectDummyData = {
+    title: 'React + Spring 스터디 / 프로젝트 모집 사이트 같이 만드실분',
+    categories: ['React', 'Typescript', 'MySQL', 'NodeJs', 'Spring'],
+    state: true,
+    totalUser: 4,
+    currentUser: 2,
+    like: 20,
+    imgUrl: '/images/dummy_image.png',
+  };
+  return (
+    <MainNewContentWrapper>
+      {category === 'project' ? (
+        <>
+          <MainNewContentTitle>새롭게 모집하는 프로젝트</MainNewContentTitle>
+          <CardCarousel>
+            <ProjectDesktopCard data={ProjectDummyData} />
+            <ProjectDesktopCard data={ProjectDummyData} />
+            <ProjectDesktopCard data={ProjectDummyData} />
+            <ProjectDesktopCard data={ProjectDummyData} />
+            <ProjectDesktopCard data={ProjectDummyData} />
+            <ProjectDesktopCard data={ProjectDummyData} />
+            <ProjectDesktopCard data={ProjectDummyData} />
+            <ProjectDesktopCard data={ProjectDummyData} />
+          </CardCarousel>
+        </>
+      ) : (
+        <>
+          <MainNewContentTitle>새롭게 모집하는 스터디</MainNewContentTitle>
+          <CardCarousel>
+            <StudyDesktopCard state={true} likeState={false} />
+            <StudyDesktopCard state={true} likeState={false} />
+            <StudyDesktopCard state={true} likeState={false} />
+            <StudyDesktopCard state={true} likeState={false} />
+            <StudyDesktopCard state={true} likeState={false} />
+            <StudyDesktopCard state={true} likeState={false} />
+            <StudyDesktopCard state={true} likeState={false} />
+            <StudyDesktopCard state={true} likeState={false} />
+          </CardCarousel>
+        </>
+      )}
+    </MainNewContentWrapper>
+  );
+};
+
+export default MainNewContent;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,11 +1,6 @@
 import { NextPage } from 'next';
-import Header from '../components/Layout/Header';
-import Footer from '../components/Layout/Footer';
-import CardState from '../components/common/CardState';
-import CardTags from '../components/common/CardTags';
-import Image from 'next/image';
-import StudyDesktopCard from '../components/common/card/study/StudyDesktopCard';
-import ProjectMobileCard from '../components/common/card/project/ProjectMobileCard/ProjectMobileCard';
+import MainNewContent from '../components/main/MainNewContent';
+import Layout from '../components/Layout';
 
 export interface ProjectDummyData {
   title: string;
@@ -18,40 +13,11 @@ export interface ProjectDummyData {
 }
 
 const Home: NextPage = () => {
-  const ProjectDummyData: ProjectDummyData = {
-    title: 'React + Spring 스터디 / 프로젝트 모집 사이트 같이 만드실분',
-    categories: ['React', 'Typescript', 'MySQL', 'NodeJs', 'Spring'],
-    state: true,
-    totalUser: 4,
-    currentUser: 2,
-    like: 20,
-    imgUrl: '/images/dummy_image.png',
-  };
   return (
-    <>
-      <Header />
-      <div>메인페이지 입니다.</div>
-      <Footer />
-      <CardState state={true}></CardState>
-      <CardState state={false}></CardState>
-      <CardTags tag={'React'} />
-      <CardTags tag={'TypeScript'} />
-      <Image
-        src={'/images/icon/heart.svg'}
-        alt="heart"
-        width={24}
-        height={24}
-      />
-      <Image
-        src={'/images/icon/heart_active.svg'}
-        alt="heart"
-        width={24}
-        height={24}
-      />
-      <StudyDesktopCard state={true} likeState={true} />
-      {/* <ProjectDesktopCard data={ProjectDummyData} /> */}
-      <ProjectMobileCard data={ProjectDummyData} />
-    </>
+    <Layout>
+      <MainNewContent category={'project'} />
+      <MainNewContent category={'study'} />
+    </Layout>
   );
 };
 

--- a/public/images/icon/chevron_next.svg
+++ b/public/images/icon/chevron_next.svg
@@ -1,0 +1,3 @@
+<svg width="13" height="20" viewBox="0 0 13 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M0.316681 17.6333L7.95001 10L0.316681 2.35L2.66668 0L12.6667 10L2.66668 20L0.316681 17.6333Z" fill="#757575"/>
+</svg>

--- a/public/images/icon/chevron_prev.svg
+++ b/public/images/icon/chevron_prev.svg
@@ -1,0 +1,3 @@
+<svg width="13" height="20" viewBox="0 0 13 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12.6833 17.6333L5.04998 10L12.6833 2.35L10.3333 0L0.333313 10L10.3333 20L12.6833 17.6333Z" fill="#757575"/>
+</svg>

--- a/styles/globalStyle.ts
+++ b/styles/globalStyle.ts
@@ -31,6 +31,7 @@ const GlobalStyles = createGlobalStyle`
     padding: 0;
     cursor: pointer;
   }
+
 `;
 
 export default GlobalStyles;


### PR DESCRIPTION
메인 페이지 케러셀 구현했습니다. 실제 데이터가 들어왔을때 공통 컴포넌트를 어떻게 적용시킬지 얘기를 좀 해봐야 할 것 같고 props가 전역적으로 쓰이는게 편할것 같아서 recoil 도입도 한번 고민을 해보는게 좋을것 같습니다. Study카드 레이아웃을 project 레이아웃과 맞추고 싶어서 패딩 10px씩 더 줬고 레이아웃 index.tsx를 만들어서 헤더와 푸터 적용시켜줬습니다

![스크린샷 2022-11-24 오전 9 08 36](https://user-images.githubusercontent.com/92736657/203666816-9b9dc231-9ff7-43c3-a88a-666b985b2372.png)
